### PR TITLE
Feature/domain - 카드 도메인 작업 하였습니다!

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_X" default="true" project-jdk-name="openjdk-22" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
   <component name="ProjectType">

--- a/backend/src/main/java/com/thirdtool/backend/Card/domain/Card.java
+++ b/backend/src/main/java/com/thirdtool/backend/Card/domain/Card.java
@@ -84,6 +84,35 @@ public class Card {
         }
     }
 
+    // success 수준 slow 버전
+    public void successReviewSlow() {
+        this.reps += 1;
+        this.successCount += 1;
+
+        if (intervalDays <= 3) {
+            intervalDays += 1; // 처음엔 조금만 증가
+        } else if (intervalDays <= 10) {
+            intervalDays += 2; // 약간씩 증가
+        } else if (intervalDays <= 20) {
+            intervalDays += 3; // 여전히 점진적으로
+        } else {
+            intervalDays = (int) (intervalDays * 1.2); // 완만한 곱셈 증가
+        }
+
+        this.dueDate = Instant.now().plusSeconds(intervalDays * 86400L);
+
+        if (intervalDays > 30) {
+            archive(); // 영구 덱으로 전환
+        }
+    }
+    // 3day에서 제공하는 4개의 블록 중 하나 -> 우선 3개라고 하자구 ㅎ
+    public void failReview(float lapseMultiplier) {
+        this.successCount = 0;
+        this.lapses += 1;
+        this.easeFactor = (int) (this.easeFactor * lapseMultiplier);
+        this.dueDate = Instant.now().plusSeconds(10 * 60); // 10분 후 복습
+    }
+
 
 
 }

--- a/backend/src/main/java/com/thirdtool/backend/Card/domain/Card.java
+++ b/backend/src/main/java/com/thirdtool/backend/Card/domain/Card.java
@@ -61,6 +61,29 @@ public class Card {
         this.intervalDays = 0;
     }
 
+    //3day에서 제공하는 4개의 블록 중 하나-> 3day로 복귀하자 permanent용
+    public void restoreToGeneralStudy() {
+        this.isArchived = false;
+        this.intervalDays = 1;
+        this.dueDate = Instant.now().plusSeconds(86400L);
+    }
+    //3day에서 제공하는 4개의 블록 중 하나
+    public void successReview() {
+        this.reps += 1;
+        this.successCount += 1;
+
+        if (successCount == 1) intervalDays += 1;
+        else if (successCount == 2) intervalDays += 2;
+        else if (successCount == 3) intervalDays += 3;
+        else intervalDays *= 2;
+
+        this.dueDate = Instant.now().plusSeconds(intervalDays * 86400L);
+
+        if (intervalDays > 30) {
+            archive(); // 영구 저장소로 이동
+        }
+    }
+
 
 
 }

--- a/backend/src/main/java/com/thirdtool/backend/Card/domain/Card.java
+++ b/backend/src/main/java/com/thirdtool/backend/Card/domain/Card.java
@@ -1,10 +1,13 @@
 package com.thirdtool.backend.Card.domain;
 
+import com.thirdtool.backend.Deck.domain.Deck;
 import com.thirdtool.backend.Note.domain.Note;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import java.time.Instant;
 
 @Getter
 @RequiredArgsConstructor
@@ -25,5 +28,39 @@ public class Card {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "deck_id")
     private Deck deck;
+
+    @Column(name = "due_date")
+    private Instant dueDate;
+
+
+    private int intervalDays; //다음 복습까지 간격을 알려주는데 사용
+    private boolean isArchived;
+    private int successCount;
+    //복습을 성공하든 실패하든 복습한 횟수
+    private int reps;
+    private int easeFactor;
+    //📌 "카드를 외우는 데 실패한 횟수"
+    private int lapses;
+
+
+
+    // ====== 학습 로직 ======
+
+    public void extendInterval(int multiplier) {
+        this.intervalDays = intervalDays * multiplier;
+        this.dueDate = Instant.now().plusSeconds(intervalDays * 86400L);
+    }
+    // permanent로 보내기 직전
+    public boolean isOverOneMonth() {
+        return intervalDays > 30;
+    }
+
+    public void archive() {
+        this.isArchived = true;
+        this.dueDate = null;
+        this.intervalDays = 0;
+    }
+
+
 
 }

--- a/backend/src/main/java/com/thirdtool/backend/Deck/domain/Deck.java
+++ b/backend/src/main/java/com/thirdtool/backend/Deck/domain/Deck.java
@@ -34,5 +34,5 @@ public class Deck {
         return this.parent == null;
     }
 
-    
+
 }


### PR DESCRIPTION
## **✨ 작업 내용**

- `Card` 도메인에 학습 상태 관리를 위한 필드 추가
  - `intervalDays`, `dueDate`, `successCount`, `reps`, `easeFactor`, `lapses`, `isArchived`
- 학습 성과에 따른 반복 주기 조정 메서드 구현
  - `successReview()`: 성공 시 증가하는 주기 반영
  - `successReviewSlow()`: 점진적 증가 방식의 느린 성공 리뷰
  - `failReview()`: 실패 시 단기 복습 유도 및 가중치 반영
- 장기 반복 학습을 위한 상태 전이 로직 구현
  - `archive()`: 일정 조건 도달 시 영구 보관 전환
  - `restoreToGeneralStudy()`: 영구 보관된 카드의 일반 학습 복귀
  - `extendInterval(int multiplier)`: 임의 배수로 학습 주기 확장 기능

## **✅ 체크리스트**

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## **🎃 새롭게 알게된 사항**

- 카드 학습 주기를 단계별로 다르게 설계하면서, 사용자의 학습 패턴에 따라 탄력적인 피드백 루프를 설계할 수 있다는 점을 체감함  
- `successCount`가 단순 누적이 아닌, 특정 구간마다 달라지는 성장 로직을 갖는 것이 사용자 경험에 큰 영향을 미친다는 점  
- 단순한 날짜 비교가 아닌 `Instant.now()`와의 계산을 통해 복습 타이밍을 정밀하게 제어할 수 있다는 점

## **🤔 고민이 필요한 점**

- `successReview`와 `successReviewSlow`의 기준을 어떻게 사용자 맞춤형으로 커스터마이징할 수 있을지?
- `archive()` 조건(`intervalDays > 30`)이 서비스 성격에 따라 유연하게 바뀔 수 있도록 정책 객체로 분리하는 리팩토링 필요성
- `easeFactor` 조정이 현재는 단순 곱셈인데, 실제 유저 이탈을 줄이기 위해 감정적 피로도를 반영한 알고리즘 적용 가능성

## **📋 참고 사항**

- 이후 `Card`의 학습 이력(History)을 기록하는 기능이 추가된다면, 상태 변화(`fail`, `success`, `archive`)의 로깅이 중요해질 수 있음  
- `dueDate`를 기준으로 한 정렬/필터 API 개발 시, `null` 상태(archived 카드 등)에 대한 예외처리가 필요함